### PR TITLE
Fix a bug in optical flow generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ T-CNN is released under the MIT License.
 
 
 ## Known Issues
-1. The optical flow generation script `gen_optical_flow.py` may generate incorrect on some Linux distributions while works correctly on OSX.
-2. Matlab engines may stall after long periods of tracking. Please consider to kill the certain matlab session to continue.
+1. Matlab engines may stall after long periods of tracking. Please consider to kill the certain matlab session to continue.
 
 ## To-do list
 - [ ] Tubelet Bayesian classifier

--- a/tools/data_proc/gen_optical_flow.py
+++ b/tools/data_proc/gen_optical_flow.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     norm_width = 500.
     bound = args.bound
 
-    images = glob.glob(os.path.join(args.vid_dir,'*'))
+    images = sorted(glob.glob(os.path.join(args.vid_dir,'*')))
     print ("Processing {}: {} files... ".format(args.vid_dir, len(images))),
     sys.stdout.flush()
     tic = time.time()


### PR DESCRIPTION
`glob.glob` return list is generally unsorted, which causes problem in optical flow generation. This may solve the known issue.
